### PR TITLE
Refactor mobile mega menu into accordion

### DIFF
--- a/assets/mega-menu-accordion.css
+++ b/assets/mega-menu-accordion.css
@@ -1,0 +1,28 @@
+.m-menu-mobile__item > .m-megamenu-mobile {
+  display: none;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+}
+.m-menu-mobile__item.is-open > .m-megamenu-mobile {
+  display: block;
+  max-height: 1000px;
+  opacity: 1;
+}
+.m-menu-mobile__toggle-button {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.m-menu-mobile__toggle-button svg {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.3s ease;
+}
+.m-menu-mobile__item.is-open > .m-menu-mobile__toggle-button svg {
+  transform: rotate(45deg);
+}

--- a/assets/mega-menu.js
+++ b/assets/mega-menu.js
@@ -7,11 +7,9 @@ class Megamenu {
       desktopSubMenus: ".m-mega-menu",
       headerMobile: ".m-header__mobile",
       menuDrawer: "#m-menu-drawer",
-      menuDrawerContent: ".m-menu-drawer__content",
       menu: ".m-menu-mobile",
       menuItems: [".m-menu-mobile__item"],
       megaMenuMobile: [".m-megamenu-mobile"],
-      backDrop: ".m-menu-drawer__backdrop",
     };
     this.menuSelectors = {
       subMenu: ".m-mega-menu",
@@ -42,9 +40,6 @@ class Megamenu {
         this.openMenu();
       }
       this.domNodes.hamburgerButtons.classList.toggle("active");
-    });
-    this.domNodes.backDrop.addEventListener("click", (e) => {
-      this.closeMenu();
     });
     this.initMobileMegaMenu();
     this.initDesktopMegaMenu();
@@ -109,50 +104,11 @@ class Megamenu {
 
   initMobileMegaMenu() {
     [...this.domNodes.menuItems].forEach((item) => {
-      const subMenuContainer = item.querySelector(".m-megamenu-mobile");
-      const backBtn = item.querySelector(".m-menu-mobile__back-button");
-
-      if (subMenuContainer) {
-        addEventDelegate({
-          context: item,
-          selector: "[data-toggle-submenu]",
-          handler: (e, target) => {
-            e.preventDefault();
-            const level = target.dataset.toggleSubmenu;
-            const parentNode = e.target.parentNode;
-            if (
-              e.target.classList.contains("m-menu-mobile__back-button") ||
-              parentNode.classList.contains("m-menu-mobile__back-button")
-            ) {
-              return;
-            }
-
-            this.openSubMenu(subMenuContainer, level);
-          },
-        });
-      }
-
-      if (backBtn) {
-        addEventDelegate({
-          context: item,
-          selector: "[data-toggle-submenu]",
-          handler: (e, target) => {
-            e.preventDefault();
-            const level = target.dataset.toggleSubmenu;
-            const parentNode = e.target.parentNode;
-            if (
-              e.target.classList.contains("m-menu-mobile__back-button") ||
-              parentNode.classList.contains("m-menu-mobile__back-button")
-            ) {
-              return;
-            }
-
-            this.openSubMenu(subMenuContainer, level);
-          },
-        });
-        backBtn.addEventListener("click", (e) => {
-          const level = e.target.dataset.level;
-          this.closeSubMenu(subMenuContainer, level);
+      const toggle = item.querySelector("[data-accordion-toggle]");
+      if (toggle) {
+        toggle.addEventListener("click", (e) => {
+          e.preventDefault();
+          this.toggleAccordion(item);
         });
       }
     });
@@ -171,38 +127,25 @@ class Megamenu {
   }
 
   closeMenu() {
-    const { menuDrawer, menu, megaMenuMobile, hamburgerButtons } = this.domNodes;
+    const { menuDrawer, menuItems, hamburgerButtons } = this.domNodes;
 
     setTimeout(() => {
-      megaMenuMobile.forEach((container) => {
-        container.classList.remove("open");
-      });
-      menu && menu.classList.remove("m-submenu-open", "m-submenu-open--level-1", "m-submenu-open--level-2");
+      menuItems.forEach((item) => item.classList.remove("is-open"));
       menuDrawer.classList.remove("open");
       document.documentElement.classList.remove("prevent-scroll");
       this.domNodes.headerMobile.classList.remove("header-drawer-open");
       hamburgerButtons.classList.remove("active");
-      // Close search
     }, this.transitionDuration);
     this.open = false;
   }
 
-  openSubMenu(subMenuContainer, level) {
-    let subMenuOpenClass = `m-submenu-open--level-${level}`;
-
-    this.domNodes.menuDrawerContent.classList.add("open-submenu");
-    this.domNodes.menu && this.domNodes.menu.classList.add("m-submenu-open");
-    this.domNodes.menu && this.domNodes.menu.classList.add(subMenuOpenClass);
-    subMenuContainer.classList.add("open");
-  }
-
-  closeSubMenu(subMenuContainer, level) {
-    let subMenuOpenClass = `m-submenu-open--level-${level}`;
-
-    level === "1" && this.domNodes.menu && this.domNodes.menu.classList.remove("m-submenu-open");
-    this.domNodes.menu && this.domNodes.menu.classList.remove(subMenuOpenClass);
-    subMenuContainer.classList.remove("open");
-    this.domNodes.menuDrawerContent.classList.remove("open-submenu");
+  toggleAccordion(item) {
+    const isOpen = item.classList.contains("is-open");
+    const siblings = item.parentElement.querySelectorAll(".m-menu-mobile__item.is-open");
+    siblings.forEach((sibling) => {
+      if (sibling !== item) sibling.classList.remove("is-open");
+    });
+    item.classList.toggle("is-open", !isOpen);
   }
 
   setMenuHeight() {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,5 +1,6 @@
 {{ 'header.css' | asset_url | stylesheet_tag }}
 {{ 'header-icons.css' | asset_url | stylesheet_tag }}
+{{ 'mega-menu-accordion.css' | asset_url | stylesheet_tag }}
 
 <script src="{{ 'mega-menu.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'header.js' | asset_url }}" defer="defer"></script>

--- a/snippets/header-menu-drawer.liquid
+++ b/snippets/header-menu-drawer.liquid
@@ -8,175 +8,9 @@
     assign menu = mobile_menu
   endif
 %}
-<style>
-  /* Inline accordion mobile menu with minimal plus/minus icons */
-  .m-menu-mobile__toggle-button {
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: all 0.25s ease;
-  }
-  
-  .m-menu-mobile__toggle-button svg {
-    width: 16px;
-    height: 16px;
-    transition: all 0.25s ease;
-  }
-  
-  /* Completely override slide-out submenu behavior and make it inline */
-  .m-megamenu-mobile {
-    position: static !important;
-    transform: translateX(0) !important;
-    background: transparent !important;
-    height: auto !important;
-    visibility: visible !important;
-    width: 100% !important;
-    z-index: auto !important;
-    display: block !important;
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.3s ease, opacity 0.3s ease;
-    opacity: 0;
-  }
-  
-  .m-megamenu-mobile.open {
-    max-height: 2000px;
-    opacity: 1;
-  }
-  
-  /* Ensure megamenu mobile wrapper doesn't cause issues */
-  .m-megamenu-mobile__wrapper {
-    overflow: visible !important;
-    display: block !important;
-    flex-direction: column !important;
-  }
-  
-  /* Hide back buttons for inline accordion */
-  .m-menu-mobile__back-button {
-    display: none !important;
-  }
-  
-  /* Style submenu items for inline display */
-  .m-submenu-mobile {
-    padding-left: 20px;
-    margin-bottom: 0 !important;
-  }
-  
-  .m-submenu-mobile .m-menu-mobile__item > a {
-    padding-left: 32px;
-    font-size: 14px;
-    opacity: 0.8;
-  }
-  
-  /* Transform plus to minus when expanded */
-  .m-menu-mobile__item.expanded .m-menu-mobile__toggle-button svg {
-    transform: rotate(45deg);
-  }
-  
-  /* Mega menu block styling for inline display */
-  .m-megamenu-mobile__block {
-    padding-left: 32px;
-    padding-right: 16px;
-    padding-top: 10px;
-  }
-  
-  /* Remove the drawer content transform behavior */
-  .m-menu-drawer__content.open-submenu {
-    /* Remove any transforms */
-  }
-  
-  /* Ensure menu items don't get hidden or transformed */
-  .m-menu-mobile .m-menu-mobile__item {
-    transform: none !important;
-    transition: none !important;
-  }
-  
-  /* Override any submenu open classes that might interfere */
-  .m-submenu-open .m-megamenu-mobile,
-  .m-submenu-open--level-1 .m-megamenu-mobile,
-  .m-submenu-open--level-2 .m-megamenu-mobile {
-    position: static !important;
-    transform: translateX(0) !important;
-  }
-</style>
 
-<script>
-  // Inline accordion functionality for mobile menu
-  document.addEventListener('DOMContentLoaded', function() {
-    // Wait for the page to fully load to ensure we override existing behavior
-    setTimeout(function() {
-      // Remove all existing event listeners by cloning and replacing elements
-      const toggleButtons = document.querySelectorAll('.m-menu-mobile__toggle-button[data-toggle-submenu]');
-      
-      toggleButtons.forEach(button => {
-        // Clone button to remove existing event listeners
-        const newButton = button.cloneNode(true);
-        button.parentNode.replaceChild(newButton, button);
-        
-        // Add our custom event listener
-        newButton.addEventListener('click', function(e) {
-          e.preventDefault();
-          e.stopPropagation();
-          e.stopImmediatePropagation();
-          
-          const menuItem = this.closest('.m-menu-mobile__item');
-          const submenu = menuItem.querySelector('.m-megamenu-mobile');
-          
-          if (submenu) {
-            const isExpanded = submenu.classList.contains('open');
-            
-            // Close all other open submenus
-            const allSubmenus = document.querySelectorAll('.m-megamenu-mobile');
-            const allMenuItems = document.querySelectorAll('.m-menu-mobile__item');
-            
-            allSubmenus.forEach(sub => {
-              if (sub !== submenu) {
-                sub.classList.remove('open');
-              }
-            });
-            
-            allMenuItems.forEach(item => {
-              if (item !== menuItem) {
-                item.classList.remove('expanded');
-              }
-            });
-            
-            // Toggle current submenu
-            if (isExpanded) {
-              submenu.classList.remove('open');
-              menuItem.classList.remove('expanded');
-            } else {
-              submenu.classList.add('open');
-              menuItem.classList.add('expanded');
-            }
-          }
-          
-          return false;
-        });
-      });
-      
-      // Override any clicks on menu links that might trigger the original behavior
-      const menuLinks = document.querySelectorAll('.m-menu-mobile__item > a[data-toggle-submenu]');
-      menuLinks.forEach(link => {
-        const newLink = link.cloneNode(true);
-        link.parentNode.replaceChild(newLink, link);
-        
-        newLink.addEventListener('click', function(e) {
-          e.preventDefault();
-          return false;
-        });
-      });
-    }, 100);
-  });
-</script>
 <div id="m-menu-drawer" class="m-menu-drawer">
-  <div class="m-menu-drawer__backdrop"></div>
-  <div class="m-menu-drawer__wrapper">
-    <div class="m-menu-drawer__content">
-      <ul class="m-menu-drawer__navigation m-menu-mobile">
+  <ul class="m-menu-mobile">
         {% for link in linklists[menu].links %}
           {% liquid
             assign title_handle = link.title | handleize
@@ -374,70 +208,38 @@
           {% endfor %}
           {% if link.links != blank %}
             <li class="m-menu-mobile__item" data-url="{{ link.url }}" data-index="{{ forloop.index0 }}">
-              <a
-                href="{{ link.url }}"
-                class="m-menu-mobile__link"
-                {% if link.url contains '#' %}
-                  data-toggle-submenu="1"
-                {% endif %}
-              >
+              <a href="{{ link.url }}" class="m-menu-mobile__link">
                 <span>{{ link.title }}</span>
               </a>
-              <span class="m-menu-mobile__toggle-button" data-toggle-submenu="1">
+              <button class="m-menu-mobile__toggle-button" type="button" data-accordion-toggle aria-label="Toggle submenu">
                 <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                   <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
                 </svg>
-              </span>
-              <div class="m-megamenu-mobile m-megamenu-mobile--level-1">
-                <div class="m-megamenu-mobile__wrapper">
-                  <button class="m-menu-mobile__back-button" data-level="1">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 17">
-                      <path fill="currentColor" d="M8.12109 15.9141c-.21093.1875-.41015.1875-.59765 0L.175781 8.53125c-.210937-.1875-.210937-.375 0-.5625L7.52344.585938c.1875-.1875.38672-.1875.59765 0l.70313.703122c.1875.1875.1875.38672 0 .59766L3.375 7.33594h11.9883c.2812 0 .4219.14062.4219.42187v.98438c0 .28125-.1407.42187-.4219.42187H3.375l5.44922 5.44924c.1875.2109.1875.4101 0 .5976l-.70313.7032z"/>
-                    </svg>
-                    <span>{{ link.title }}</span>
-                  </button>
-                  <ul class="m-submenu-mobile">
-                    {% for child in link.links %}
-                      <li class="m-menu-mobile__item" data-url="{{ link.url }}">
-                        <a
-                          href="{{ child.url }}"
-                          class="m-menu-mobile__link"
-                          {% if child.url contains '#' %}
-                            data-toggle-submenu="2"
-                          {% endif %}
-                        >
-                          <span>{{ child.title }}</span>
-                        </a>
-                        {% if child.links != blank %}
-                          <span class="m-menu-mobile__toggle-button" data-toggle-submenu="2">
-                            <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                              <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-                            </svg>
-                          </span>
-                          <div class="m-megamenu-mobile m-megamenu-mobile--level-2">
-                            <div class="m-megamenu-mobile__wrapper">
-                              <button class="m-menu-mobile__back-button" data-level="2">
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 17">
-                                  <path fill="currentColor" d="M8.12109 15.9141c-.21093.1875-.41015.1875-.59765 0L.175781 8.53125c-.210937-.1875-.210937-.375 0-.5625L7.52344.585938c.1875-.1875.38672-.1875.59765 0l.70313.703122c.1875.1875.1875.38672 0 .59766L3.375 7.33594h11.9883c.2812 0 .4219.14062.4219.42187v.98438c0 .28125-.1407.42187-.4219.42187H3.375l5.44922 5.44924c.1875.2109.1875.4101 0 .5976l-.70313.7032z"/>
-                                </svg>
-                                <span>{{ child.title }}</span>
-                              </button>
-                              <ul class="m-submenu-mobile">
-                                {% render 'mega-menu-link' for child.links as link %}
-                              </ul>
-                            </div>
-                          </div>
-                        {% endif %}
-                      </li>
-                    {% endfor %}
-                  </ul>
-                  {% if has_mega_item == true and block_type != blank %}
-                    <div class="m-megamenu-mobile__block">
-                      {{ block_type }}
-                    </div>
-                  {% endif %}
-                </div>
-              </div>
+              </button>
+              <ul class="m-megamenu-mobile m-megamenu-mobile--level-1 m-submenu-mobile">
+                {% for child in link.links %}
+                  <li class="m-menu-mobile__item" data-url="{{ link.url }}">
+                    <a href="{{ child.url }}" class="m-menu-mobile__link">
+                      <span>{{ child.title }}</span>
+                    </a>
+                    {% if child.links != blank %}
+                      <button class="m-menu-mobile__toggle-button" type="button" data-accordion-toggle aria-label="Toggle submenu">
+                        <svg fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                          <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+                        </svg>
+                      </button>
+                      <ul class="m-megamenu-mobile m-megamenu-mobile--level-2 m-submenu-mobile">
+                        {% render 'mega-menu-link' for child.links as link %}
+                      </ul>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+                {% if has_mega_item == true and block_type != blank %}
+                  <li class="m-megamenu-mobile__block">
+                    {{ block_type }}
+                  </li>
+                {% endif %}
+              </ul>
             </li>
           {% else %}
             {% render 'mega-menu-link' with link as link, has_mega_item: has_mega_item, block_type: block_type %}
@@ -445,6 +247,4 @@
         {% endfor %}
       </ul>
       {% render 'mega-menu-customer', section: section %}
-    </div>
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- Switch mobile menu submenus to an accordion pattern with inline `<ul>` and toggle buttons
- Replace slide-out submenu logic in `mega-menu.js` with `is-open` accordion toggling
- Add dedicated accordion styles and wire them into header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfba6134c8329827abb051187f0cd